### PR TITLE
icloud_backup.py - add logic to download photos where the local file is zero bytes due to previously interrupted process

### DIFF
--- a/icloud_backup.py
+++ b/icloud_backup.py
@@ -94,6 +94,12 @@ def backup_photos_to_local(api, album_name, dest_directory):
         checked_photos_count += 1
         if photo.filename not in existing_photos:
             photos_to_backup.append(photo)
+        else:
+            # Assume photo.filename contains the file name as a string
+            file_path = args.destination + "/" + photo.filename
+            # Check if the file exists and is zero bytes on disk and still needs to be downloaded
+            if os.path.exists(file_path) and os.path.getsize(file_path) == 0:
+                photos_to_backup.append(photo)
         print(f"🔍 Verificando fotos: {checked_photos_count}", end='\r')
 
     stats['items_count'] = checked_photos_count


### PR DESCRIPTION
If photo downloads do not complete because the process is interrupted, they can be on disk as zero byte files. I added logic to check for each photo in the iCloud album if the corresponding local photo file exists and is zero bytes, and if so, to download it.